### PR TITLE
Fix: hits URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,4 +219,4 @@ Well, what if I told you there are tools that can improve this significantl... <
   <a href="https://blog.anishde.dev/"><img src="https://img.shields.io/badge/See More-1F75FE?style=for-the-badge" alt="More Blog Posts" height="50px" width="150px" /></a>
 </div>
   
-![Hits - Counting since Jan 25 2022](https://hits.link/hits?url=https%3A%2F%2Fgithub.com%2FAnishDe12020)
+![Hits - Counting since Jan 25 2022](https://hits-app.vercel.app/hits?url=https%3A%2F%2Fgithub.com%2FAnishDe12020)


### PR DESCRIPTION
we've recently dropped the hits.link domain because the renewal price was $180, please use the updated/stable one :D!

sorry for the inconvenience!